### PR TITLE
Add ability to read environment vars for API keys first

### DIFF
--- a/movie_search/movie.rb
+++ b/movie_search/movie.rb
@@ -11,7 +11,7 @@ end
 
 def movie
   # This is a live API key, don't absue it
-  api_key = '946f500a'
+  api_key = ENV['OMDBAPI_API_KEY'] || '946f500a'
 
   puts
   print 'Movie =>  '

--- a/weather/weather.rb
+++ b/weather/weather.rb
@@ -6,7 +6,7 @@ require 'json'
 
 def weather_search
   # This key is functional, please don't abuse it
-  api_key = "6510b92495fd472ca30155709172803&q"
+  api_key = ENV['APIXU_API_KEY'] || "6510b92495fd472ca30155709172803&q"
 
   # Uses IP to get current city
   begin


### PR DESCRIPTION
Instead of reading from the hardcoded API keys first, provide users with
the ability to use their own.